### PR TITLE
Added implicits for Rx.Dynamic as well (not just Rx the super class)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.SbtGit.git._
 
 organization := "com.timushev"
 name := "scalatags-rx"
-version := "0.3.0"
+version := "0.3.1"
 
 version := {
   (version.value, gitCurrentTags.value) match {

--- a/src/main/scala/scalatags/rx/attributes.scala
+++ b/src/main/scala/scalatags/rx/attributes.scala
@@ -9,6 +9,7 @@ import scalatags.rx.ext._
 trait RxAttrInstances {
 
   implicit def rxAttrValue[T: AttrValue](implicit ctx: Ctx.Owner): AttrValue[Rx[T]] = new RxAttrValue[T, Rx[T]]
+  implicit def rxAttrValueDyn[T: AttrValue](implicit ctx: Ctx.Owner): AttrValue[Rx.Dynamic[T]] = new RxAttrValue[T, Rx.Dynamic[T]]
   implicit def varAttrValue[T: AttrValue](implicit ctx: Ctx.Owner): AttrValue[Var[T]] = new RxAttrValue[T, Var[T]]
 
   class RxAttrValue[T, F <: Rx[T]](implicit av: AttrValue[T], ctx: Ctx.Owner) extends AttrValue[F] {

--- a/src/main/scala/scalatags/rx/nodes.scala
+++ b/src/main/scala/scalatags/rx/nodes.scala
@@ -13,16 +13,18 @@ import scala.collection.immutable
 import scala.collection.immutable.Iterable
 import scala.language.implicitConversions
 import scalatags.JsDom.all._
-import scalatags.jsdom
 import scalatags.rx.ext._
 
 trait RxNodeInstances {
 
-  implicit class rxStringFrag(v: Rx[String])(implicit ctx: Ctx.Owner) extends jsdom.Frag {
+  implicit class rxStringFrag(v: Rx[String])(implicit ctx: Ctx.Owner) extends Frag {
     def render: dom.Text = {
       val node = dom.document.createTextNode(v.now)
-      v foreach { s => node.replaceData(0, node.length, s)} attachTo node
+      v foreach { s => node.replaceData(0, node.length, s)}
       node
+    }
+    def applyTo(t: Element) = {
+      t.appendChild(render)
     }
   }
 

--- a/src/main/scala/scalatags/rx/styles.scala
+++ b/src/main/scala/scalatags/rx/styles.scala
@@ -2,7 +2,6 @@ package scalatags.rx
 
 import org.scalajs.dom._
 import rx._
-import rx.opmacros._
 
 import scala.language.implicitConversions
 import scalatags.JsDom.all._
@@ -18,6 +17,15 @@ trait RxStyleInstances {
   implicit def varIsRxForPixelStyleValue[T](implicit x: PixelStyleValue[Rx[T]], ctx: Ctx.Owner): PixelStyleValue[Var[T]] =
     new PixelStyleValue[Var[T]] {
       override def apply(s: Style, v: Var[T]): StylePair[Element, _] = x.apply(s, v)
+    }
+
+  implicit def rxDynIsRxForStyleValue[T](implicit x: StyleValue[Rx[T]], ctx: Ctx.Owner): StyleValue[Rx.Dynamic[T]] =
+    new StyleValue[Rx.Dynamic[T]] {
+      override def apply(t: Element, s: Style, v: Rx.Dynamic[T]): Unit = x.apply(t, s, v)
+    }
+  implicit def rxDynIsRxForPixelStyleValue[T](implicit x: PixelStyleValue[Rx[T]], ctx: Ctx.Owner): PixelStyleValue[Rx.Dynamic[T]] =
+    new PixelStyleValue[Rx.Dynamic[T]] {
+      override def apply(s: Style, v: Rx.Dynamic[T]): StylePair[Element, _] = x.apply(s, v)
     }
 
   implicit def rxStyleValue[T: StyleValue](implicit ctx: Ctx.Owner): StyleValue[Rx[T]] = new RxStyleValue[T]

--- a/src/test/scala/scalatags/rx/RxAttrInstancesSuite.scala
+++ b/src/test/scala/scalatags/rx/RxAttrInstancesSuite.scala
@@ -20,6 +20,11 @@ object RxAttrInstancesSuite extends TestSuite {
         val node = div(widthA := c.rx).render
         testRx(c, node.getAttribute("width"), "10px", "20px")
       }
+      "Rx.Dynamic" - {
+        val direction = Var("up")
+        val node = div(cls := Rx("icon-chevron-" + direction())).render
+        testRx(direction, node.getAttribute("class"), "icon-chevron-up", "down" -> "icon-chevron-down")
+      }
     }
     "int attribute" - {
       val c = Var(10)
@@ -29,6 +34,10 @@ object RxAttrInstancesSuite extends TestSuite {
       }
       "Rx" - {
         val node = div(widthA := c.rx).render
+        testRx(c, node.getAttribute("width"), "10", 20 -> "20")
+      }
+      "Rx.Dynamic" - {
+        val node = div(widthA := Rx(c())).render
         testRx(c, node.getAttribute("width"), "10", 20 -> "20")
       }
     }

--- a/src/test/scala/scalatags/rx/RxDataConvertersSuite.scala
+++ b/src/test/scala/scalatags/rx/RxDataConvertersSuite.scala
@@ -17,6 +17,9 @@ object RxDataConvertersSuite extends TestSuite {
       "Rx" - {
         assert(a.rx.px.now == 1.px)
       }
+      "Rx.Dynamic" - {
+        assert(Rx(a()).px.now == 1.px)
+      }
     }
   }
 }

--- a/src/test/scala/scalatags/rx/RxNodeInstancesSuite.scala
+++ b/src/test/scala/scalatags/rx/RxNodeInstancesSuite.scala
@@ -21,6 +21,10 @@ object RxNodeInstancesSuite extends TestSuite {
         val node = span(c.rx).render
         testRx(c, node.textContent, "a", "b")
       }
+      "Rx.Dyn" - {
+        val node = span(Rx(c())).render
+        testRx(c, node.textContent, "a", "b")
+      }
     }
     "text node join" - {
       val c = Var("")
@@ -41,6 +45,10 @@ object RxNodeInstancesSuite extends TestSuite {
         val node = div(c.rx).render
         testRx(c, node.innerHTML, "<div></div>", span().render -> "<span></span>")
       }
+      "Rx.Dynamic" - {
+        val node = div(Rx(c())).render
+        testRx(c, node.innerHTML, "<div></div>", span().render -> "<span></span>")
+      }
     }
     "child node sequence" - {
       val c = Var[Vector[Element]](Vector(div().render))
@@ -50,6 +58,10 @@ object RxNodeInstancesSuite extends TestSuite {
       }
       "Rx" - {
         val node = div(c.rx).render
+        testRx(c, node.innerHTML, "<div></div>", Vector(span().render) -> "<span></span>")
+      }
+      "Rx.Dynamic" - {
+        val node = div(Rx(c())).render
         testRx(c, node.innerHTML, "<div></div>", Vector(span().render) -> "<span></span>")
       }
     }

--- a/src/test/scala/scalatags/rx/RxStyleInstancesSuite.scala
+++ b/src/test/scala/scalatags/rx/RxStyleInstancesSuite.scala
@@ -20,6 +20,10 @@ object RxStyleInstancesSuite extends TestSuite {
         val node = div(color := c.rx).render
         testRx(c, node.style.getPropertyValue("color"), "blue", "green")
       }
+      "Rx.Dynamic" - {
+        val node = div(color := Rx(c())).render
+        testRx(c, node.style.getPropertyValue("color"), "blue", "green")
+      }
     }
     "string pixel style" - {
       val c = Var("10px")
@@ -31,6 +35,10 @@ object RxStyleInstancesSuite extends TestSuite {
         val node = div(width := c.rx).render
         testRx(c, node.style.getPropertyValue("width"), "10px", "20px")
       }
+      "Rx.Dynamic" - {
+        val node = div(width := Rx(c())).render
+        testRx(c, node.style.getPropertyValue("width"), "10px", "20px")
+      }
     }
     "int pixel style" - {
       val c = Var(10)
@@ -40,6 +48,10 @@ object RxStyleInstancesSuite extends TestSuite {
       }
       "Rx" - {
         val node = div(width := c.rx).render
+        testRx(c, node.style.getPropertyValue("width"), "10px", 20 -> "20px")
+      }
+      "Rx.Dynamic" - {
+        val node = div(width := Rx(c())).render
         testRx(c, node.style.getPropertyValue("width"), "10px", 20 -> "20px")
       }
     }


### PR DESCRIPTION
When I started using the updated version of scalatags-rx in my project, I noticed that using Rx like this would no longer work: `div(Rx("Hello Mr. " + name()))`  because Rx.apply actually returns a Rx.Dynamic -- a _subtype_ of Rx.

So in order to make it work, I either had to upcast the Rx everywhere I used it: `div(Rx("Hello Mr. " + name()): Rx)` or with a temporary value: `val nameRx: Rx = Rx("Hello Mr. " + name()); div(nameRx)` which is a huge hassle.

So I added some additional implicits for Rx.Dynamic as well, not just Rx and Var. I noticed you'd done something similar for the Var-type earlier, so I just followed in that pattern. 

The reason we have to add yet another bunch implicit conversions is the change in Scala.rx. Earlier Rx was the supertype, and Var a subtype of that.  Now Rx is the supertype, while Var and Dynamic are the subtypes. 