### PR TITLE
Update project to work with scala.rx 0.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.SbtGit.git._
 
 organization := "com.timushev"
 name := "scalatags-rx"
-version := "0.3.1"
+version := "0.3.0"
 
 version := {
   (version.value, gitCurrentTags.value) match {
@@ -15,8 +15,14 @@ version := {
 crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")
 scalaVersion := "2.12.1"
 
+def scalaRxVersion(scalaVersion: String): String =
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 10)) => "0.3.2"
+      case _ => "0.4.0"
+    }
+
 libraryDependencies ++= Seq(
-  "com.lihaoyi" %%% "scalarx" % "0.4.0",
+  "com.lihaoyi" %%% "scalarx" % scalaRxVersion(scalaVersion.value),
   "com.lihaoyi" %%% "scalatags" % "0.6.2",
   "com.lihaoyi" %%% "utest" % "0.4.4" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
 )
 
 testFrameworks += new TestFramework("utest.runner.Framework")
-
+jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv()
 requiresDOM := true
 
 lazy val `scalatags-rx` = project in file(".") enablePlugins ScalaJSPlugin

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+enablePlugins(GitVersioning)
+enablePlugins(ScalaJSPlugin)
+
 import com.typesafe.sbt.SbtGit.git._
 
 organization := "com.timushev"
@@ -8,12 +11,12 @@ version := {
   (version.value, gitCurrentTags.value) match {
     case (v, w :: Nil) if s"v$v" == w => v
     case (v, Nil) => s"$v-SNAPSHOT"
-    case _ => fail("Version and tag do not match")
+    case _ => throw new IllegalArgumentException("Version and tag do not match")
   }
 }
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")
-scalaVersion := "2.12.1"
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.6")
+scalaVersion := "2.12.6"
 
 def scalaRxVersion(scalaVersion: String): String =
     CrossVersion.partialVersion(scalaVersion) match {
@@ -23,12 +26,11 @@ def scalaRxVersion(scalaVersion: String): String =
 
 libraryDependencies ++= Seq(
   "com.lihaoyi" %%% "scalarx" % scalaRxVersion(scalaVersion.value),
-  "com.lihaoyi" %%% "scalatags" % "0.6.2",
-  "com.lihaoyi" %%% "utest" % "0.4.4" % "test"
+  "com.lihaoyi" %%% "scalatags" % "0.6.7",
+  "com.lihaoyi" %%% "utest" % "0.6.6" % "test"
 )
 
 testFrameworks += new TestFramework("utest.runner.Framework")
-jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv()
-requiresDOM := true
+jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 
 lazy val `scalatags-rx` = project in file(".") enablePlugins ScalaJSPlugin

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.SbtGit.git._
 
 organization := "com.timushev"
 name := "scalatags-rx"
-version := "0.3.0"
+version := "0.3.1"
 
 version := {
   (version.value, gitCurrentTags.value) match {
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1")
 scalaVersion := "2.12.1"
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi" %%% "scalarx" % "0.3.2",
+  "com.lihaoyi" %%% "scalarx" % "0.4.0",
   "com.lihaoyi" %%% "scalatags" % "0.6.2",
   "com.lihaoyi" %%% "utest" % "0.4.4" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")

--- a/src/main/scala/scalatags/rx/nodes.scala
+++ b/src/main/scala/scalatags/rx/nodes.scala
@@ -33,7 +33,7 @@ trait RxNodeInstances {
       rx.triggerLater {
         val current = rx.now
         val previous = atomicReference.getAndSet(current)
-        container.replaceChild(current, previous)
+        container.replaceChild(current, previous): Unit
       }
     }
   }


### PR DESCRIPTION
Since Scala.rx 0.3.2 and Scala.rx 0.4.0 seem to be binary incompatible I was wondering if it would be possible to update scalatags.rx accordingly. For this to work I also had to increment the scala-js version. Without the update to Scala.rx 0.4.0 I wouldn't be able to use scalatags-rx since some of my other 3rd-party libs depend on Scala.rx 0.4.0 and I could imagine others having similar problems.